### PR TITLE
Swap to http.StatusCodes and format

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,10 +21,10 @@ package config
 
 import (
 	"flag"
-	"io"
-	"os"
 	"github.com/naoina/toml"
 	"golang.org/x/net/context"
+	"io"
+	"os"
 )
 
 type Website struct {
@@ -119,8 +119,8 @@ func ReadTokensFile(cfg *TwitchScrape, overwrite bool) {
 	}
 	if info, err := f.Stat(); err == nil && (info.Size() == 0 || overwrite) {
 		var tokenStr string
-		tokenStr = "accesstoken=\""+ cfg.AccessToken +"\"\r\n"
-		tokenStr += "refreshtoken=\""+ cfg.RefreshToken +"\"\r\n"
+		tokenStr = "accesstoken=\"" + cfg.AccessToken + "\"\r\n"
+		tokenStr += "refreshtoken=\"" + cfg.RefreshToken + "\"\r\n"
 		if info.Size() > 0 {
 			f.Truncate(0)
 			f.Seek(0, 0)

--- a/twitchpubsub/api/api.go
+++ b/twitchpubsub/api/api.go
@@ -1,18 +1,19 @@
 package api
 
 import (
-	"io"
-	"net/http"
-	"io/ioutil"
-	"time"
 	"crypto/tls"
-	"github.com/destinygg/twitch-subscriber-sync/internal/debug"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
 	"github.com/destinygg/twitch-subscriber-sync/internal/config"
+	d "github.com/destinygg/twitch-subscriber-sync/internal/debug"
 	"golang.org/x/net/context"
 )
 
 type Api struct {
-	cfg *config.AppConfig
+	cfg    *config.AppConfig
 	client http.Client
 }
 
@@ -22,7 +23,7 @@ func Init(ctx context.Context) context.Context {
 		client: http.Client{
 			Timeout: 5 * time.Second,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{},
+				TLSClientConfig:       &tls.Config{},
 				ResponseHeaderTimeout: 5 * time.Second,
 			},
 		},
@@ -53,7 +54,7 @@ func (a *Api) call(method, url string, body io.Reader) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	if err != nil || res.StatusCode < 200 || res.StatusCode >= 300 {
+	if err != nil || res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		data, _ := ioutil.ReadAll(res.Body)
 		d.PF(2, "Request failed: %#v, body was \n%v", err, string(data))
 		return nil, err

--- a/twitchpubsub/main.go
+++ b/twitchpubsub/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"time"
 	"github.com/destinygg/twitch-subscriber-sync/internal/config"
 	"github.com/destinygg/twitch-subscriber-sync/internal/debug"
 	"github.com/destinygg/twitch-subscriber-sync/twitchpubsub/api"
 	"github.com/destinygg/twitch-subscriber-sync/twitchpubsub/twitch"
 	"golang.org/x/net/context"
+	"time"
 )
 
 func main() {

--- a/twitchscrape/api/api.go
+++ b/twitchscrape/api/api.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/destinygg/twitch-subscriber-sync/internal/config"
-	"github.com/destinygg/twitch-subscriber-sync/internal/debug"
+	d "github.com/destinygg/twitch-subscriber-sync/internal/debug"
 	"github.com/destinygg/twitch-subscriber-sync/twitchscrape/twitch"
 	"golang.org/x/net/context"
 )
@@ -41,14 +41,14 @@ type Api struct {
 
 	mu sync.Mutex
 	// subs are keyed by ids that are alphanumeric but not necessarily only digits
-	subs       map[string]int
-	client     http.Client
+	subs   map[string]int
+	client http.Client
 }
 
 func Init(ctx context.Context) context.Context {
 	api := &Api{
-		cfg:        config.FromContext(ctx),
-		subs:       map[string]int{},
+		cfg:  config.FromContext(ctx),
+		subs: map[string]int{},
 		client: http.Client{
 			Timeout: 5 * time.Second,
 			Transport: &http.Transport{
@@ -81,7 +81,7 @@ func (a *Api) call(method, url string, body io.Reader) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	if err != nil || res.StatusCode < 200 || res.StatusCode >= 300 {
+	if err != nil || res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		data, _ := ioutil.ReadAll(res.Body)
 		d.PF(2, "Request failed: %#v, body was \n%v", err, string(data))
 		return nil, err

--- a/twitchscrape/main.go
+++ b/twitchscrape/main.go
@@ -20,12 +20,12 @@
 package main
 
 import (
-	"time"
 	"github.com/destinygg/twitch-subscriber-sync/internal/config"
 	"github.com/destinygg/twitch-subscriber-sync/internal/debug"
 	"github.com/destinygg/twitch-subscriber-sync/twitchscrape/api"
 	"github.com/destinygg/twitch-subscriber-sync/twitchscrape/twitch"
 	"golang.org/x/net/context"
+	"time"
 )
 
 func main() {


### PR DESCRIPTION
- Usage of http status code constants (such as `http.StatusOK`) for happiness
- Runs `go fmt ./...` across the project (my IDE does this automatically), as it's general go convention