### PR TITLE
Dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.18-alpine AS builder
+
+RUN apk add --update --no-cache \
+  ca-certificates tzdata openssh git mercurial && update-ca-certificates \
+  && rm -rf /var/cache/apk/*
+
+WORKDIR /src
+
+COPY go.mod* go.sum* ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=0 go install ./...
+
+FROM alpine
+
+RUN adduser -S -D -H -h /app appuser
+USER appuser
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/bin/* /bin/
+
+WORKDIR /etc/twitch-subscriber-sync/
+COPY --from=builder /src/settings.cfg.example settings.cfg
+
+# TODO: Doesn't seem that the website Addr is used anywhere
+ENV PORT=8080
+EXPOSE $PORT
+
+CMD ["twitchpubsub"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+
+  twitchpubsub:
+    build: .
+
+  twitchscrape:
+    build: .
+    command: ["twitchscrape"]


### PR DESCRIPTION
- Baseline `Dockerfile` compatible with both executables based on `CMD`
- Simple `docker-compose.yml` that demonstrates running the processes

> Added a note about `PORT` not being implemented, which is generally considered to be the standard you want over `ADDR` (or a concatenation of the two so you can optionally specify the listenAddr entirely - Although it doesn't seem that the `config.Website.Addr` is being used just yet though, so I figured leaving it would be fine for now.